### PR TITLE
add iframe name option

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ IFrame.prototype.setHTML = function(opts) {
   tempIframe.style.height = '100%'
   tempIframe.style.border = '0'
   tempIframe.sandbox = opts.sandboxAttributes.join(' ')
+  if (opts.name) tempIframe.setAttribute('name', opts.name)
   // generate HTML string
   var htmlSrc = tempIframe.outerHTML
   // insert HTML into container

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ you can pass this into the constructor or `setHTML`
 
 ```
 {
+  name: name of the iframe,
   src: if src url is passed in use that (this mode ignores body/head/html options),
   body: string contents for `<body>`
   head: string contents for `<head>`


### PR DESCRIPTION
This PR adds the `name` option for the iframe name attribute.
This is helpful to target/distinguish several iframes on a page.
